### PR TITLE
Parse references from source text instead of files only + possible to do custom Nuget.exe resolving

### DIFF
--- a/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptParserTests.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptParserTests.cs
@@ -1,9 +1,8 @@
+using Microsoft.CodeAnalysis.Text;
+
 namespace Dotnet.Script.NuGetMetadataResolver.Tests
 {
-    using System;
-    using System.IO;
     using System.Linq;
-    using System.Reflection;
     using Microsoft.CodeAnalysis.NuGet.Tests;
     using Microsoft.Extensions.Logging;
 
@@ -46,9 +45,9 @@ namespace Dotnet.Script.NuGetMetadataResolver.Tests
         public void ShouldResolveMultiplePackages_FromSingleSource()
         {
             var parser = new ScriptParser(CreateLoggerFactory());
-            var script = "#r \"nuget:Package,1.0.0\"\r\n#r \"nuget:AnotherPackage,2.0.0\"\r\n";
+            var script = SourceText.From("#r \"nuget:Package,1.0.0\"\r\n#r \"nuget:AnotherPackage,2.0.0\"\r\n");
 
-            var result = parser.ParseFromSource(new[] { script });
+            var result = parser.ParseFrom(new[] { script });
             result.PackageReferences.Count.ShouldBe(2);
             result.PackageReferences.First().Id.ShouldBe("Package");
             result.PackageReferences.First().Version.ShouldBe("1.0.0");
@@ -60,10 +59,10 @@ namespace Dotnet.Script.NuGetMetadataResolver.Tests
         public void ShouldResolveMultiplePackages_FromMultipleSources()
         {
             var parser = new ScriptParser(CreateLoggerFactory());
-            var script1 = "#r \"nuget:Package,1.0.0\"";
-            var script2 = "#r \"nuget:AnotherPackage,2.0.0\"";
+            var script1 = SourceText.From("#r \"nuget:Package,1.0.0\"");
+            var script2 = SourceText.From("#r \"nuget:AnotherPackage,2.0.0\"");
 
-            var result = parser.ParseFromSource(new[] { script1, script2 });
+            var result = parser.ParseFrom(new[] { script1, script2 });
             result.PackageReferences.Count.ShouldBe(2);
             result.PackageReferences.First().Id.ShouldBe("Package");
             result.PackageReferences.First().Version.ShouldBe("1.0.0");

--- a/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptParserTests.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptParserTests.cs
@@ -1,8 +1,7 @@
-using Microsoft.CodeAnalysis.Text;
-
 namespace Dotnet.Script.NuGetMetadataResolver.Tests
 {
     using System.Linq;
+    using Microsoft.CodeAnalysis.Text;
     using Microsoft.CodeAnalysis.NuGet.Tests;
     using Microsoft.Extensions.Logging;
 

--- a/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptParserTests.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptParserTests.cs
@@ -43,6 +43,35 @@ namespace Dotnet.Script.NuGetMetadataResolver.Tests
         }
 
         [Fact]
+        public void ShouldResolveMultiplePackages_FromSingleSource()
+        {
+            var parser = new ScriptParser(CreateLoggerFactory());
+            var script = "#r \"nuget:Package,1.0.0\"\r\n#r \"nuget:AnotherPackage,2.0.0\"\r\n";
+
+            var result = parser.ParseFromSource(new[] { script });
+            result.PackageReferences.Count.ShouldBe(2);
+            result.PackageReferences.First().Id.ShouldBe("Package");
+            result.PackageReferences.First().Version.ShouldBe("1.0.0");
+            result.PackageReferences.Last().Id.ShouldBe("AnotherPackage");
+            result.PackageReferences.Last().Version.ShouldBe("2.0.0");
+        }
+
+        [Fact]
+        public void ShouldResolveMultiplePackages_FromMultipleSources()
+        {
+            var parser = new ScriptParser(CreateLoggerFactory());
+            var script1 = "#r \"nuget:Package,1.0.0\"";
+            var script2 = "#r \"nuget:AnotherPackage,2.0.0\"";
+
+            var result = parser.ParseFromSource(new[] { script1, script2 });
+            result.PackageReferences.Count.ShouldBe(2);
+            result.PackageReferences.First().Id.ShouldBe("Package");
+            result.PackageReferences.First().Version.ShouldBe("1.0.0");
+            result.PackageReferences.Last().Id.ShouldBe("AnotherPackage");
+            result.PackageReferences.Last().Version.ShouldBe("2.0.0");
+        }
+
+        [Fact]
         public void ShouldParseTargetFramework()
         {
             var parser = new ScriptParser(CreateLoggerFactory());

--- a/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptProjectProviderTests.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptProjectProviderTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Dotnet.Script.NuGetMetadataResolver.Tests
+﻿using Microsoft.CodeAnalysis.Text;
+
+namespace Dotnet.Script.NuGetMetadataResolver.Tests
 {
     using System;
     using System.IO;
@@ -31,7 +33,7 @@
         public void ShouldCreateNet46Project_FromSource()
         {
             ScriptProjectProvider p = ScriptProjectProvider.Create(CreateLoggerFactory());
-            var script = "Console.WriteLine(\"TEST\");";
+            var script = SourceText.From("Console.WriteLine(\"TEST\");");
 
             var result = p.CreateProject(new []{script});
             var json = File.ReadAllText(result.PathToProjectJson);

--- a/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptProjectProviderTests.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptProjectProviderTests.cs
@@ -27,6 +27,17 @@
             json.ShouldContain("net46");
         }
 
+        [Fact]
+        public void ShouldCreateNet46Project_FromSource()
+        {
+            ScriptProjectProvider p = ScriptProjectProvider.Create(CreateLoggerFactory());
+            var script = "Console.WriteLine(\"TEST\");";
+
+            var result = p.CreateProject(new []{script});
+            var json = File.ReadAllText(result.PathToProjectJson);
+            json.ShouldContain("net46");
+        }
+
 
         private static ILoggerFactory CreateLoggerFactory()
         {

--- a/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptProjectProviderTests.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver.Tests/ScriptProjectProviderTests.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.CodeAnalysis.Text;
-
-namespace Dotnet.Script.NuGetMetadataResolver.Tests
+﻿namespace Dotnet.Script.NuGetMetadataResolver.Tests
 {
     using System;
     using System.IO;
     using System.Reflection;
+    using Microsoft.CodeAnalysis.Text;
     using Microsoft.CodeAnalysis.NuGet.Tests;
     using Microsoft.Extensions.Logging;
     using Shouldly;

--- a/src/Dotnet.Script.NuGetMetadataResolver/INugetCommandResolver.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver/INugetCommandResolver.cs
@@ -1,0 +1,7 @@
+﻿namespace Dotnet.Script.NuGetMetadataResolver
+{
+    public interface INugetCommandResolver
+    {
+        string ResolveNugetCommand();
+    }
+}

--- a/src/Dotnet.Script.NuGetMetadataResolver/IScriptParser.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver/IScriptParser.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis.Text;
+
 namespace Dotnet.Script.NuGetMetadataResolver
 {
     using System.Collections.Generic;
@@ -24,6 +26,6 @@ namespace Dotnet.Script.NuGetMetadataResolver
         /// <param name="csxSources">A list of csx source for which to parse and resolve NuGet references.</param>
         /// <returns>A <see cref="ParseResult"/>
         /// instance that contains a list of NuGet reference found within the scripts.</returns>
-        ParseResult ParseFromSource(IEnumerable<string> csxSources);
+        ParseResult ParseFrom(IEnumerable<SourceText> csxSources);
     }
 }

--- a/src/Dotnet.Script.NuGetMetadataResolver/IScriptParser.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver/IScriptParser.cs
@@ -3,7 +3,7 @@ namespace Dotnet.Script.NuGetMetadataResolver
     using System.Collections.Generic;
 
     /// <summary>
-    /// Represents a class that is capable of parsing a set of script files 
+    /// Represents a class that is capable of parsing a set of script files and scripts.
     /// and return information about NuGet references and the target framework.
     /// </summary>
     public interface IScriptParser
@@ -16,5 +16,14 @@ namespace Dotnet.Script.NuGetMetadataResolver
         /// <returns>A <see cref="ParseResult"/>
         /// instance that contains a list of NuGet reference found within the script files.</returns>
         ParseResult ParseFrom(IEnumerable<string> csxFiles);
+
+        /// <summary>
+        /// Parses the given set of <paramref name="csxSources"/> and returns a <see cref="ParseResult"/>
+        /// instance that contains a list of NuGet reference found within the scripts.
+        /// </summary>
+        /// <param name="csxSources">A list of csx source for which to parse and resolve NuGet references.</param>
+        /// <returns>A <see cref="ParseResult"/>
+        /// instance that contains a list of NuGet reference found within the scripts.</returns>
+        ParseResult ParseFromSource(IEnumerable<string> csxSources);
     }
 }

--- a/src/Dotnet.Script.NuGetMetadataResolver/NugetCommandResolver.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver/NugetCommandResolver.cs
@@ -38,33 +38,23 @@ namespace Dotnet.Script.NuGetMetadataResolver
             if (!File.Exists(pathToNuget))
             {
                 using (Stream input = typeof(ScriptProjectProvider).GetTypeInfo().Assembly.GetManifestResourceStream("Dotnet.Script.NuGetMetadataResolver.NuGet.NuGet.exe"))
+                using (Stream output = File.OpenWrite(pathToNuget))
                 {
-                    byte[] byteData = StreamToBytes(input);
-                    File.WriteAllBytes(pathToNuget, byteData);
+                    CopyStream(input, output);
                 }
             }
         }
 
         /// <summary>
-        /// StreamToBytes - Converts a Stream to a byte array. Eg: Get a Stream from a file,url, or open file handle.
+        /// Copies the contents of input to output. Doesn't close either stream.
         /// </summary>
-        /// <param name="input">input is the stream we are to return as a byte array</param>
-        /// <returns>byte[] The Array of bytes that represents the contents of the stream</returns>
-        private static byte[] StreamToBytes(Stream input)
+        public static void CopyStream(Stream input, Stream output)
         {
-
-            int capacity = input.CanSeek ? (int)input.Length : 0; //Bitwise operator - If can seek, Capacity becomes Length, else becomes 0.
-            using (MemoryStream output = new MemoryStream(capacity)) //Using the MemoryStream output, with the given capacity.
+            byte[] buffer = new byte[8 * 1024];
+            int len;
+            while ((len = input.Read(buffer, 0, buffer.Length)) > 0)
             {
-                int readLength;
-                byte[] buffer = new byte[capacity/*4096*/];  //An array of bytes
-                do
-                {
-                    readLength = input.Read(buffer, 0, buffer.Length);   //Read the memory data, into the buffer
-                    output.Write(buffer, 0, readLength); //Write the buffer to the output MemoryStream incrementally.
-                }
-                while (readLength != 0); //Do all this while the readLength is not 0
-                return output.ToArray();  //When finished, return the finished MemoryStream object as an array.
+                output.Write(buffer, 0, len);
             }
         }
     }

--- a/src/Dotnet.Script.NuGetMetadataResolver/NugetCommandResolver.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver/NugetCommandResolver.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Dotnet.Script.NuGetMetadataResolver
+{
+    public class NugetCommandResolver : INugetCommandResolver
+    {
+        private static readonly string PathToNuget;
+
+        static NugetCommandResolver()
+        {
+            var directory = Path.GetDirectoryName(new Uri(typeof(ScriptProjectProvider).GetTypeInfo().Assembly.CodeBase)
+                .LocalPath);
+            PathToNuget = Path.Combine(directory, "NuGet350.exe");
+        }
+
+
+        public string ResolveNugetCommand()
+        {
+            ExtractNugetExecutable(PathToNuget);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return PathToNuget;
+            }
+            return MonoCommand(PathToNuget);
+        }
+
+        protected virtual string MonoCommand(string pathToNuget)
+        {
+            return "mono " + PathToNuget;
+        }
+
+        private void ExtractNugetExecutable(string pathToNuget)
+        {
+            if (!File.Exists(pathToNuget))
+            {
+                using (Stream input = typeof(ScriptProjectProvider).GetTypeInfo().Assembly.GetManifestResourceStream("Dotnet.Script.NuGetMetadataResolver.NuGet.NuGet.exe"))
+                {
+                    byte[] byteData = StreamToBytes(input);
+                    File.WriteAllBytes(pathToNuget, byteData);
+                }
+            }
+        }
+
+        /// <summary>
+        /// StreamToBytes - Converts a Stream to a byte array. Eg: Get a Stream from a file,url, or open file handle.
+        /// </summary>
+        /// <param name="input">input is the stream we are to return as a byte array</param>
+        /// <returns>byte[] The Array of bytes that represents the contents of the stream</returns>
+        private static byte[] StreamToBytes(Stream input)
+        {
+
+            int capacity = input.CanSeek ? (int)input.Length : 0; //Bitwise operator - If can seek, Capacity becomes Length, else becomes 0.
+            using (MemoryStream output = new MemoryStream(capacity)) //Using the MemoryStream output, with the given capacity.
+            {
+                int readLength;
+                byte[] buffer = new byte[capacity/*4096*/];  //An array of bytes
+                do
+                {
+                    readLength = input.Read(buffer, 0, buffer.Length);   //Read the memory data, into the buffer
+                    output.Write(buffer, 0, readLength); //Write the buffer to the output MemoryStream incrementally.
+                }
+                while (readLength != 0); //Do all this while the readLength is not 0
+                return output.ToArray();  //When finished, return the finished MemoryStream object as an array.
+            }
+        }
+    }
+}

--- a/src/Dotnet.Script.NuGetMetadataResolver/ScriptParser.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver/ScriptParser.cs
@@ -51,6 +51,33 @@
             return new ParseResult(allPackageReferences, currentTargetFramework);
         }
 
+        public ParseResult ParseFromSource(IEnumerable<string> csxSources)
+        {
+            HashSet<PackageReference> allPackageReferences = new HashSet<PackageReference>();                        
+            string currentTargetFramework = null;
+            var count = 0;
+            foreach (var csxSource in csxSources)
+            {
+                logger.LogDebug($"Parsing source index {count++}");
+                var packageReferences = ReadPackageReferences(csxSource);
+                allPackageReferences.UnionWith(packageReferences);
+                string targetFramework = ReadTargetFramework(csxSource);
+                if (targetFramework != null)
+                {
+                    if (currentTargetFramework != null && targetFramework != currentTargetFramework)
+                    {
+                        logger.LogWarning($"Found multiple target frameworks. Using {currentTargetFramework}.");
+                    }
+                    else
+                    {
+                        currentTargetFramework = targetFramework;
+                    }
+                }
+            }
+
+            return new ParseResult(allPackageReferences, currentTargetFramework);
+        }
+
         private IEnumerable<PackageReference> ReadPackageReferences(string fileContent)
         {
             const string pattern = @"^\s*#r\s*""nuget:\s*(.+)\s*,\s*(.*)""";

--- a/src/Dotnet.Script.NuGetMetadataResolver/ScriptParser.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver/ScriptParser.cs
@@ -1,4 +1,6 @@
-﻿namespace Dotnet.Script.NuGetMetadataResolver
+﻿using Microsoft.CodeAnalysis.Text;
+
+namespace Dotnet.Script.NuGetMetadataResolver
 {
     using System.Collections.Generic;
     using System.IO;
@@ -51,17 +53,18 @@
             return new ParseResult(allPackageReferences, currentTargetFramework);
         }
 
-        public ParseResult ParseFromSource(IEnumerable<string> csxSources)
+        public ParseResult ParseFrom(IEnumerable<SourceText> csxSources)
         {
             HashSet<PackageReference> allPackageReferences = new HashSet<PackageReference>();                        
             string currentTargetFramework = null;
             var count = 0;
             foreach (var csxSource in csxSources)
             {
+                var sourceTextString = csxSource.ToString();
                 logger.LogDebug($"Parsing source index {count++}");
-                var packageReferences = ReadPackageReferences(csxSource);
+                var packageReferences = ReadPackageReferences(sourceTextString);
                 allPackageReferences.UnionWith(packageReferences);
-                string targetFramework = ReadTargetFramework(csxSource);
+                string targetFramework = ReadTargetFramework(sourceTextString);
                 if (targetFramework != null)
                 {
                     if (currentTargetFramework != null && targetFramework != currentTargetFramework)

--- a/src/Dotnet.Script.NuGetMetadataResolver/ScriptProjectProvider.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver/ScriptProjectProvider.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis.Text;
+
 namespace Dotnet.Script.NuGetMetadataResolver
 {
     using System;
@@ -53,9 +55,9 @@ namespace Dotnet.Script.NuGetMetadataResolver
             return CreateProject(parseresult, pathToProjectJson, targetFramework);
         }
 
-        public ScriptProjectInfo CreateProject(IEnumerable<string> sources, string targetFramework = "net46")
+        public ScriptProjectInfo CreateProject(IEnumerable<SourceText> sources, string targetFramework = "net46")
         {
-            var parseresult = scriptParser.ParseFromSource(sources);
+            var parseresult = scriptParser.ParseFrom(sources);
 
             var pathToProjectJson = GetPathToProjectJson(".");
             return CreateProject(parseresult, pathToProjectJson, targetFramework);

--- a/src/Dotnet.Script.NuGetMetadataResolver/ScriptProjectProvider.cs
+++ b/src/Dotnet.Script.NuGetMetadataResolver/ScriptProjectProvider.cs
@@ -4,7 +4,6 @@ namespace Dotnet.Script.NuGetMetadataResolver
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
     using System.Runtime.InteropServices;
     using Microsoft.Extensions.Logging;
 
@@ -17,23 +16,19 @@ namespace Dotnet.Script.NuGetMetadataResolver
     {
         private readonly ICommandRunner commandRunner;
         private readonly IScriptParser scriptParser;
-        private static string PathToNuget;
+        private readonly INugetCommandResolver nugetCommandResolver;
 
-        static ScriptProjectProvider()
-        {
-            var directory = Path.GetDirectoryName(new Uri(typeof(ScriptProjectProvider).GetTypeInfo().Assembly.CodeBase).LocalPath);
-            PathToNuget = Path.Combine(directory, "NuGet350.exe");
-        }
-        
         /// <summary>
         /// Initializes a new instance of the <see cref="ScriptProjectProvider"/> class.
         /// </summary>
         /// <param name="commandRunner">The <see cref="ICommandRunner"/> that is responsible for executing the NuGet command.</param>
         /// <param name="scriptParser">The <see cref="IScriptParser"/> that is responsible for parsing NuGet references from script files.</param>
-        public ScriptProjectProvider(ICommandRunner commandRunner, IScriptParser scriptParser)
+        /// <param name="nugetCommandResolver">The <see cref="INugetCommandResolver"/> that is responsible for providing nuget.exe command</param>
+        public ScriptProjectProvider(ICommandRunner commandRunner, IScriptParser scriptParser, INugetCommandResolver nugetCommandResolver)
         {
             this.commandRunner = commandRunner;
             this.scriptParser = scriptParser;
+            this.nugetCommandResolver = nugetCommandResolver;
         }
 
         /// <summary>
@@ -43,7 +38,7 @@ namespace Dotnet.Script.NuGetMetadataResolver
         /// <returns></returns>
         public static ScriptProjectProvider Create(ILoggerFactory loggerFactory)
         {
-            return new ScriptProjectProvider(new CommandRunner(loggerFactory), new ScriptParser(loggerFactory));
+            return new ScriptProjectProvider(new CommandRunner(loggerFactory), new ScriptParser(loggerFactory), new NugetCommandResolver());
         }
 
 
@@ -94,15 +89,8 @@ namespace Dotnet.Script.NuGetMetadataResolver
 
         private void Restore(string pathToProjectJson)
         {
-            ExtractNugetExecutable();
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                commandRunner.Execute(PathToNuget, $"restore {pathToProjectJson}");
-            }
-            else
-            {
-                commandRunner.Execute("mono", $"{PathToNuget} restore {pathToProjectJson}");
-            }                        
+            var pathToNuget = nugetCommandResolver.ResolveNugetCommand();
+            commandRunner.Execute(pathToNuget, $"restore {pathToProjectJson}");
         }
 
         private static string GetPathToProjectJson(string targetDirectory)
@@ -122,43 +110,6 @@ namespace Dotnet.Script.NuGetMetadataResolver
             }
             var pathToProjectJson = Path.Combine(pathToProjectJsonDirectory, "project.json");
             return pathToProjectJson;
-        }
-
-        private void ExtractNugetExecutable()
-        {
-            if (!File.Exists(PathToNuget))
-            {
-                using (Stream input = typeof(ScriptProjectProvider).GetTypeInfo().Assembly.GetManifestResourceStream("Dotnet.Script.NuGetMetadataResolver.NuGet.NuGet.exe"))
-                {
-
-                    byte[] byteData = StreamToBytes(input);
-                    File.WriteAllBytes(PathToNuget, byteData);
-                }
-            }                  
-        }
-
-        /// <summary>
-        /// StreamToBytes - Converts a Stream to a byte array. Eg: Get a Stream from a file,url, or open file handle.
-        /// </summary>
-        /// <param name="input">input is the stream we are to return as a byte array</param>
-        /// <returns>byte[] The Array of bytes that represents the contents of the stream</returns>
-        static byte[] StreamToBytes(Stream input)
-        {
-
-            int capacity = input.CanSeek ? (int)input.Length : 0; //Bitwise operator - If can seek, Capacity becomes Length, else becomes 0.
-            using (MemoryStream output = new MemoryStream(capacity)) //Using the MemoryStream output, with the given capacity.
-            {
-                int readLength;
-                byte[] buffer = new byte[capacity/*4096*/];  //An array of bytes
-                do
-                {
-                    readLength = input.Read(buffer, 0, buffer.Length);   //Read the memory data, into the buffer
-                    output.Write(buffer, 0, readLength); //Write the buffer to the output MemoryStream incrementally.
-                }
-                while (readLength != 0); //Do all this while the readLength is not 0
-                return output.ToArray();  //When finished, return the finished MemoryStream object as an array.
-            }
-
         }
     }
 }


### PR DESCRIPTION
Hi,
I've done some changes to make it possible to parse scripts that are already loaded instead of requiring to have them as files on disk.

Also, I've extracted the Nuget.exe functionallity to an own class + interface, to make it possible for library consumers to have custom logic to resolve what exe to use on different platforms.

Sorry for packing much stuff into one single pull request.

/Niclas
